### PR TITLE
feat: FormHeader 컴포넌트 작성 및 스토리북 에러 해결

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,5 +12,29 @@ const config: StorybookConfig = {
     options: {},
   },
   staticDirs: ['..\\public'],
+  webpackFinal: async (config) => {
+    if (!config.module || !config.module.rules) {
+      return config;
+    }
+
+    config.module.rules = [
+      ...config.module.rules.map((rule) => {
+        if (!rule || rule === '...') {
+          return rule;
+        }
+
+        if (rule.test && /svg/.test(String(rule.test))) {
+          return { ...rule, exclude: /\.svg$/i };
+        }
+        return rule;
+      }),
+      {
+        test: /\.svg$/,
+        use: ['@svgr/webpack'],
+      },
+    ];
+
+    return config;
+  },
 };
 export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -16,6 +16,9 @@ const preview: Preview = {
     msw: {
       handlers,
     },
+    nextjs: {
+      appDirectory: true,
+    },
   },
   loaders: [mswLoader],
 };

--- a/src/assets/back.svg
+++ b/src/assets/back.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 16H25.3333" stroke="#292929" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16 6.66675L6.66663 16.0001L16 25.3334" stroke="#292929" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/common/formheader/FormHeader.stories.tsx
+++ b/src/components/common/formheader/FormHeader.stories.tsx
@@ -1,0 +1,23 @@
+import { Meta, StoryObj } from '@storybook/react';
+import FormHeader from './FormHeader';
+
+const meta = {
+  title: 'Components/Common/FormHeader',
+  component: FormHeader,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+    },
+  },
+} satisfies Meta<typeof FormHeader>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+  args: {
+    title: 'Default Title',
+  },
+} satisfies Story;

--- a/src/components/common/formheader/FormHeader.test.tsx
+++ b/src/components/common/formheader/FormHeader.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useRouter } from 'next/navigation';
+import FormHeader from './FormHeader';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('@/assets/icons/back.svg', () => {
+  const MockedIcon = () => <div>back-icon</div>;
+  return MockedIcon;
+});
+
+describe('FormHeader', () => {
+  const mockRouter = {
+    back: jest.fn(),
+  };
+
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue(mockRouter);
+  });
+
+  it('타이틀이 올바르게 렌더링되어야 합니다', () => {
+    const title = 'Test Title';
+    render(<FormHeader title={title} />);
+    expect(screen.getByText(title)).toBeInTheDocument();
+  });
+
+  it('SVG 뒤로가기 버튼이 올바르게 렌더링되어야 합니다', () => {
+    render(<FormHeader title="Test Title" />);
+    expect(screen.getByText('back-icon')).toBeInTheDocument();
+  });
+
+  it('뒤로가기 버튼을 클릭했을 때, router.back이 호출되어야 합니다', () => {
+    render(<FormHeader title="Test Title" />);
+    const backButton = screen.getByRole('button');
+    fireEvent.click(backButton);
+
+    expect(mockRouter.back).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/common/formheader/FormHeader.tsx
+++ b/src/components/common/formheader/FormHeader.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import Back from '@/assets/back.svg';
+
+interface Props {
+  title: string;
+}
+
+const FormHeader = ({ title }: Props) => {
+  const router = useRouter();
+
+  return (
+    <header className="z-100 flex h-[60px] items-center border-b border-[#DADDE1] px-5 py-3.5">
+      <button
+        type="button"
+        onClick={() => {
+          router.back();
+        }}
+        aria-label="뒤로가기 버튼, 이전 페이지로 이동"
+        className="z-10 m-0 cursor-pointer rounded border-none bg-transparent p-0 outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+      >
+        <Back width={32} height={32} aria-hidden="true" />
+      </button>
+      <h1 className="-ml-8 flex-1 text-center text-lg font-semibold">
+        {title}
+      </h1>
+    </header>
+  );
+};
+
+export default FormHeader;


### PR DESCRIPTION
## 작업 개요

> 스토리북 에러 해결 
> FormHeader 컴포넌트 작성 

## 작업 상세

1.  넥스트js 스토리북 호환 에러 해결
`Error: invariant expected app router to be mounted`
위 에러는 해당 컴포넌트 안에서 useRouter(from next/navigation)를 사용하여 나타났다. 그 이유는 스토리북은 pages 디렉터리를 기본으로 지원하고 있기 때문이다. 

해결방법: 스토리북한테 app 디렉터리를 사용한다고 알려주면 된다.

2. svg 스토리북 호환 에러 해결
`Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.`
위 에러는 스토리북은 기본적으로 웹팩을 사용하고 있고 file-loader가 사용되는데, svg파일을 import 하는 과저에서 file-loader가 객체 형태로 변환해서 생긴 문제다. 

해결방법: file-loader가 svg 모듈을 무시하도록 하고 svg를 @svg/webpack이 처리하도록 해서 import할 때, 리액트 컴포넌트로 변환해준다.

3. 웹 접근성을 고려하여 로그인, 회원가입 및 여행 만들기 페이지에서 사용하는 헤더 작성

4. 테스트 작성 

## 작업 결과 (스크린샷 및 gif)
![image](https://github.com/user-attachments/assets/b0af801f-e1c6-46da-9d5f-a3d96bb43b48)




close #19 
