### PR TITLE
refactor: 지금까지 작성한 컴포넌트의 arbitrary 색상 값을 커스텀 색상으로 적용하였습니다.

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -20,13 +20,16 @@ const Login = () => {
           </Link>
 
           <div className="mt-6 flex justify-center divide-x text-sm">
-            <Link href="/find-id" className="pr-2.5 text-[#878A92]">
+            <Link href="/find-id" className="pr-2.5 text-label-alternative">
               아이디 찾기
             </Link>
-            <Link href="/find-password" className="px-2.5 text-[#878A92]">
+            <Link
+              href="/find-password"
+              className="px-2.5 text-label-alternative"
+            >
               비밀번호 찾기
             </Link>
-            <Link href="/" className="pl-2.5 text-[#2563EB] underline">
+            <Link href="/" className="pl-2.5 text-primary-normal underline">
               둘러보기
             </Link>
           </div>

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -12,8 +12,8 @@ const Signup = () => {
       </div>
 
       <div className="mb-[50px] mt-6 flex justify-center text-sm">
-        <span className="text-[#9199A5]">이미 회원이신가요?</span>
-        <Link href="/login" className="ml-[6px] text-[#2563EB] underline">
+        <span className="text-gray-400">이미 회원이신가요?</span>
+        <Link href="/login" className="ml-[6px] text-primary-normal underline">
           로그인
         </Link>
       </div>

--- a/src/components/auth/input/AuthEmailSert.tsx
+++ b/src/components/auth/input/AuthEmailSert.tsx
@@ -78,7 +78,8 @@ const AuthEmailSert = memo(() => {
         size="withButton"
         classNameCondition={{
           hidden: !viewEmailCode,
-          'border-[#4A8AF8] focus:border-[#4A8AF8]': emailCode.isValid,
+          'border-status-infomative focus:border-status-infomative':
+            emailCode.isValid,
         }}
       >
         <Button
@@ -92,13 +93,13 @@ const AuthEmailSert = memo(() => {
       </AuthText>
 
       {viewEmailCode && !isVerified && (
-        <span className="absolute bottom-0 text-xs text-[#ED672C]">
+        <span className="absolute bottom-0 text-xs text-status-error">
           {due > 0 ? formatTimeToMMSS(due) : '인증 시간이 초과되었습니다.'}
         </span>
       )}
 
       {isVerified && (
-        <span className="absolute bottom-0 text-xs text-[#4A8AF8]">
+        <span className="absolute bottom-0 text-xs text-status-infomative">
           {AUTH_SUCCESS_MESSAGE.emailCode}
         </span>
       )}

--- a/src/components/auth/input/AuthPassword.tsx
+++ b/src/components/auth/input/AuthPassword.tsx
@@ -24,7 +24,9 @@ const AuthPassword = memo(
       <div className="relative">
         <label htmlFor={name}>
           {AUTH_LABEL[name]}
-          {important && <span className="ml-[2px] text-[#4a8af8]">*</span>}
+          {important && (
+            <span className="ml-[2px] text-status-infomative">*</span>
+          )}
         </label>
 
         <PasswordInput
@@ -34,8 +36,9 @@ const AuthPassword = memo(
           onChange={onChange}
           className="mb-6"
           classNameCondition={{
-            'border-[#222]': isValid,
-            'border-red-500 focus:border-red-500': Boolean(value) && !isValid,
+            'border-label-normal': isValid,
+            'border-status-error focus:border-status-error':
+              Boolean(value) && !isValid,
           }}
         />
 

--- a/src/components/auth/input/AuthText.tsx
+++ b/src/components/auth/input/AuthText.tsx
@@ -61,8 +61,11 @@ const AuthText = memo(
             className={className}
             classNameCondition={{
               ...classNameCondition,
-              'border-[#222]': isValid,
-              'border-red-500 focus:border-red-500': Boolean(value) && !isValid,
+              'border-line-strong': isValid,
+              'disabled:border-status-infomative':
+                name === 'emailCode' && isValid,
+              'border-status-error focus:border-status-error':
+                Boolean(value) && !isValid,
               'mx-0': Boolean(children),
             }}
             onChange={onChange}
@@ -72,7 +75,7 @@ const AuthText = memo(
 
         <p
           className={cn('absolute bottom-0 text-xs', {
-            'text-[#EC524B]': name !== 'emailCode' && value && !isValid,
+            'text-status-error': name !== 'emailCode' && value && !isValid,
           })}
         >
           {name !== 'emailCode' && value && !isValid

--- a/src/components/common/button/Button.test.tsx
+++ b/src/components/common/button/Button.test.tsx
@@ -26,14 +26,14 @@ describe('Button 컴포넌트', () => {
 
     const button = screen.getByText('비활성화 버튼');
     expect(button).toBeDisabled();
-    expect(button).toHaveClass('disabled:bg-[#F7F7F8]');
+    expect(button).toHaveClass('disabled:bg-background-alternative');
   });
 
   it('variant 스타일이 정상적으로 적용되어야 한다', () => {
     render(<Button label="white 버튼" fill="white" />);
 
     const button = screen.getByText('white 버튼');
-    expect(button).toHaveClass('bg-white', 'border', 'border-[#E0E0E2]');
+    expect(button).toHaveClass('bg-white', 'border', 'border-line-strong');
   });
 
   it('size variant가 정상적으로 적용되어야 한다', () => {

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -2,12 +2,12 @@ import cn from '@/utils/cn';
 import { cva, VariantProps } from 'class-variance-authority';
 
 const ButtonVariants = cva(
-  'rounded disabled:border disabled:border-[#E0E0E2] disabled:bg-[#F7F7F8] disabled:text-[#878A92]',
+  'rounded disabled:border disabled:border-line-normal disabled:bg-background-alternative disabled:text-label-alternative',
   {
     variants: {
       fill: {
-        default: 'bg-[#222222] text-white',
-        white: 'bg-white border border-[#E0E0E2]',
+        default: 'bg-label-normal text-white',
+        white: 'bg-white border border-line-strong',
       },
       size: {
         default: 'w-[335px] h-[52px]',

--- a/src/components/common/input/PasswordInput.tsx
+++ b/src/components/common/input/PasswordInput.tsx
@@ -5,7 +5,7 @@ import PwClose from '@/assets/pw_close.svg';
 import { useState } from 'react';
 
 const PasswordInputVariants = cva(
-  'mt-[6px] rounded-md border border-[#e0e0e2] p-2 mx-auto outline-none h-[46px] text-xs focus:border-[#222] p-4',
+  'mt-[6px] rounded-md border border-line-normal p-2 mx-auto outline-none h-[46px] text-xs focus:border-label-normal p-4',
   {
     variants: {
       size: {

--- a/src/components/common/input/PasswordInput.tsx
+++ b/src/components/common/input/PasswordInput.tsx
@@ -62,9 +62,9 @@ const PasswordInput = ({
         onClick={clickButton}
       >
         {isOpen ? (
-          <PwClose width={20} height={20} />
-        ) : (
           <PwOpen width={20} height={20} />
+        ) : (
+          <PwClose width={20} height={20} />
         )}
       </button>
     </div>

--- a/src/components/common/input/TextInput.tsx
+++ b/src/components/common/input/TextInput.tsx
@@ -2,7 +2,7 @@ import cn from '@/utils/cn';
 import { cva, VariantProps } from 'class-variance-authority';
 
 const TextInputVariants = cva(
-  'mt-[6px] rounded-md border border-[#e0e0e2] p-2 mx-auto outline-none h-[46px] text-xs focus:border-[#222] disabled:border-[#e0e0e2] disabled:bg-[#f7f7f8] p-4',
+  'mt-[6px] rounded-md border border-line-normal p-2 mx-auto outline-none h-[46px] text-xs focus:border-line-strong disabled:border-line-normal disabled:bg-interaction-disable p-4',
   {
     variants: {
       size: {


### PR DESCRIPTION
## 작업 개요

> 커스텀 색상 적용.

## 작업 상세

1. 커스텀 색상 적용
2. password 암호화 아이콘 반대로 되어있던 것 정상화 했습니다.


## 작업 결과 (스크린샷 및 gif)

![image](https://github.com/user-attachments/assets/ca4afa47-e485-48c1-bb7f-1ae221d93b7d)


## 리뷰 요구사항

close #47 
close #
