### PR TITLE
refactor: Textarea 컴포넌트 리팩토링

### DIFF
--- a/src/components/common/textarea/Textarea.test.tsx
+++ b/src/components/common/textarea/Textarea.test.tsx
@@ -60,7 +60,7 @@ describe('Textarea 컴포넌트', () => {
     );
     const textarea = screen.getByRole('textbox');
 
-    expect(textarea).toHaveClass('w-[295px]');
+    expect(textarea).toHaveClass('h-[60px]');
   });
 
   it('추가 className이 정상적으로 적용되어야 한다', () => {

--- a/src/components/common/textarea/Textarea.tsx
+++ b/src/components/common/textarea/Textarea.tsx
@@ -1,15 +1,30 @@
 import cn from '@/utils/cn';
 import { cva, VariantProps } from 'class-variance-authority';
 
-const TextareaVariants = cva(
-  'rounded border py-3 px-4 outline-none text-sm resize-none ',
+const TextareaContainerVariants = cva(
+  'relative inline-block rounded border transition-colors ',
   {
     variants: {
       size: {
         default:
-          'w-[335px] h-[160px] border-line-strong placeholder-shown:border-line-normal focus:border-line-strong',
+          'w-[335px] h-[160px] focus-within:border-line-strong border-line-normal',
         small:
-          'w-[295px] h-[90px] border-label-assistive placeholder-shown:border-background-alternative focus:border-label-neutral',
+          'w-[295px] h-[90px] focus-within:border-label-neutral border-background-alternative',
+      },
+    },
+    defaultVariants: {
+      size: 'default',
+    },
+  },
+);
+
+const TextareaVariants = cva(
+  'rounded py-3 px-4 outline-none text-sm resize-none pb-0 placeholder-shown:border-none w-full',
+  {
+    variants: {
+      size: {
+        default: 'h-[130px]',
+        small: 'h-[60px]',
       },
     },
     defaultVariants: {
@@ -34,14 +49,22 @@ const Textarea = ({
   value,
   placeholder,
   maxLength = 100,
-  size,
+  size = 'default',
   className,
   classNameCondition,
   onChange,
 }: Props) => {
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const inputValue = e.target.value;
+    if (inputValue.length <= maxLength) {
+      onChange(e);
+    }
+  };
   return (
     <div
-      className={`relative inline-block ${size === 'default' ? 'h-[160px]' : 'h-[90px]'}`}
+      className={cn(TextareaContainerVariants({ size }), {
+        'border-line-strong': !!value,
+      })}
     >
       <textarea
         id={name}
@@ -54,10 +77,10 @@ const Textarea = ({
           TextareaVariants({ size, className }),
           classNameCondition,
         )}
-        onChange={onChange}
+        onChange={handleChange}
         aria-label={`최대 ${maxLength}자 입력 가능 textarea`}
       />
-      <span className="absolute bottom-5 right-4 text-xs text-[#989BA1]">
+      <span className="absolute bottom-3 right-4 text-xs text-[#989BA1]">
         {value.length}/{maxLength}
       </span>
     </div>


### PR DESCRIPTION
## 작업 개요

>  Textarea 컴포넌트 리팩토링

## 작업 상세

- Textarea의 maxLength가 101이 되었다가 100으로 줄어드는 에러 수정
- 글자 제한 표시가 본문과 겹쳐지게 나오는 부분 수정
- 글자 수 제한 표시가 size="small"에 맞춰져 있는 부분 수정


close #131 
