### PR TITLE
fix: PCHeader 컴포넌트 디자인 및 모킹 로직 수정

### DIFF
--- a/src/components/header/PCHeader.tsx
+++ b/src/components/header/PCHeader.tsx
@@ -9,7 +9,7 @@ const PCHeader = () => {
   const { data: user } = useGetUser();
 
   return (
-    <header className="fixed z-30 h-auto w-full border-b border-line-neutral bg-white px-5 py-[14px] transition-all duration-300 ease-in-out xl:py-6">
+    <header className="fixed top-0 z-30 h-auto w-full border-b border-line-neutral bg-white px-5 py-[14px] transition-all duration-300 ease-in-out xl:py-6">
       <span className="m-auto flex max-w-[1400px] items-center justify-between">
         <Link href="/" aria-label="WEGO 로고">
           <LogoBlue width={80} height={32} />

--- a/src/mocks/handlers/user/getUserInfo.ts
+++ b/src/mocks/handlers/user/getUserInfo.ts
@@ -3,7 +3,11 @@ import userInfo from '@/mocks/data/user/userInfo.json';
 
 export const getUserInfo = http.get(
   `${process.env.NEXT_PUBLIC_BASE_URL}/users`,
-  async () => {
+  async ({ cookies }) => {
+    const token = cookies.accessToken;
+    if (!token) {
+      return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 });
+    }
     return HttpResponse.json(userInfo, { status: 200 });
   },
 );


### PR DESCRIPTION
- fixed top value 0으로 설정
- getUser api 모킹에서 토큰 없을 경우 에러 반환
