### PR TITLE
fix: 배포 사이트 관련 에러 해결 및 사이드 이펙트 해결

### DIFF
--- a/src/api/auth/verifyToken.ts
+++ b/src/api/auth/verifyToken.ts
@@ -1,5 +1,14 @@
+import type { NextRequest } from 'next/server';
 import { http } from '../fetcher';
 
-export const verifyToken = () => {
-  return http.get<any>('/auth/token/verify');
+export const verifyToken = (request?: NextRequest) => {
+  const config = request
+    ? {
+        headers: {
+          Cookie: request.headers.get('cookie') || '',
+        },
+      }
+    : undefined;
+
+  return http.get<{ status: number }>('/auth/token/verify', config);
 };

--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -47,6 +47,10 @@ async function fetcher<T>(
 
   const response = await fetch(`${BASE_URL}${endpoint}`, mergedConfig);
 
+  if (endpoint === '/auth/token/verify') {
+    return { status: response.status } as T;
+  }
+
   if (!response.ok) {
     const error = new Error('API request failed') as FetcherError;
     error.status = response.status;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -22,7 +22,7 @@ const authRedirect = async (request: NextRequest, response: NextResponse) => {
   const verifyResponse =
     process.env.NODE_ENV === 'development'
       ? await verifyTokenMock(request)
-      : await verifyToken();
+      : await verifyToken(request);
 
   // 토큰 유효성 검증 통과가 필요한 페이지의 redirect
   if (

--- a/src/queries/user/useEditProfile.tsx
+++ b/src/queries/user/useEditProfile.tsx
@@ -44,7 +44,7 @@ const useEditProfile = () => {
         icon: ModalSuccessIcon,
         confirmText: '확인',
         onConfirm: () => {
-          router.push('/mypage');
+          router.replace('/mypage');
         },
       });
     },


### PR DESCRIPTION
## 작업 개요

배포관련 문제였던것들
1. favicon이 16px 기본 하나였는데 여러 환경에 대처하지 못하는 기본사이즈입니다. 32px 로 바꾸어 해결
2. 미들웨어는 edge runtime에 실행됩니다. 로컬개발환경에서는 edge 런타임이 완벽하게 시뮬레이션되지 않아서 로컬 개발환경에서 잘 되는 것이 배포때 안될 수 있습니다.
  - 쿠키가 자동으로 실려가지 않습니다.
  - 미들웨어에서 request.header 에서 쿠키를 읽어 verifyToken api 파라미터로 넘겨      주어 해결했습니다.
3. 우리 앱 전체적으로 헤더 네비게이션이 쓰이고 거기서 verifyToken을 판단하는데 400이 올 경우 반환 값을 저희가 설정하지 않고 에러처리만 해주고 있었는데 이게 기존 클라이언트나 node.js에서 실행되었다면 (로컬환경) 우리가 설정한 에러처리로 빠졌겠지만 미들웨어 edge runtime 에서는 사이트 전체가 500에러를 보여주게 됩니다.
