### PR TITLE
refactor: 여행 리스트 탈출 버튼 적용, 이미지 onload 수정, 테스트 코드 에러사항 수정 반영

### DIFF
--- a/src/components/a11y/ListSkip.tsx
+++ b/src/components/a11y/ListSkip.tsx
@@ -2,27 +2,29 @@ interface Props {
   skipId: string;
   skipLabel: string;
   currentElement: number;
+  onClick?: () => void;
 }
 
 export const ListSkip = {
   /**
    * 리스트 탈출을 위한 링크 컴포넌트
    */
-  Link: ({ currentElement, skipId, skipLabel }: Partial<Props>) => {
+  Link: ({ currentElement, skipId, skipLabel, onClick }: Partial<Props>) => {
     const pageInfo = currentElement
       ? ` (현재 ${currentElement} : ''}번째 요소)`
       : '';
 
     return (
-      <li className="col-span-full">
+      <div className="col-span-full">
         <a
           href={`#${skipId}`}
           className="sr-only focus:not-sr-only focus:block focus:border focus:bg-white focus:p-2 focus:text-center"
           aria-label={`${skipLabel || '목록'} 탈출하기${pageInfo}`}
+          onClick={onClick}
         >
           {skipLabel || '목록'} 탈출하기
         </a>
-      </li>
+      </div>
     );
   },
 

--- a/src/components/card/travel/TravelCardBig.tsx
+++ b/src/components/card/travel/TravelCardBig.tsx
@@ -79,7 +79,8 @@ const TravelCardBig = ({
           width={400}
           height={200}
           className="h-full w-full object-cover opacity-0 duration-300 ease-in-out"
-          onLoadingComplete={(img) => {
+          onLoad={(event) => {
+            const img = event.currentTarget;
             img.classList.remove('opacity-0');
             img.classList.add('opacity-100');
           }}

--- a/src/components/review/new/participant/InputImage.test.tsx
+++ b/src/components/review/new/participant/InputImage.test.tsx
@@ -6,7 +6,9 @@ import InputImage from './InputImage';
 describe('InputImage', () => {
   it('이미지 등록버튼이 렌더링됩니다', async () => {
     render(<InputImage />);
-    const fileInput = screen.getByLabelText('이미지 등록');
+    const fileInput = screen.getByLabelText(
+      '이미지 등록하기, 이미지 하나당 5MB이내로 등록 가능 합니다',
+    );
     expect(fileInput).toBeInTheDocument();
   });
 });

--- a/src/components/review/reviewList/reviewContents/ReviewContents.tsx
+++ b/src/components/review/reviewList/reviewContents/ReviewContents.tsx
@@ -32,29 +32,27 @@ const ReviewContents = () => {
       {reviewsData && (
         <ul className="grid grid-cols-2 gap-x-[15px] gap-y-6 md:grid-cols-3 md:gap-5 xl:grid-cols-4">
           {reviewsData.pages.map((page, pageIndex) =>
-            page.data.content
-              ? page.data.content.map((review, reviewIndex) => (
-                  <li key={`${filters.sortOrder}-${review.reviewId}`}>
-                    <ReviewCard
-                      reviewId={review.reviewId}
-                      nickname={review.nickname}
-                      profileImage={review.profileImage}
-                      reviewImage={review.reviewImage}
-                      title={review.title}
-                      content={review.content}
-                      starRating={review.starRating}
-                      travelLocation={review.travelLocation}
-                      createdAt={review.createdAt}
-                      likesFlag={review.likesFlag ?? false}
-                    />
-                    <ListSkip.Link
-                      skipId="review-list-end"
-                      skipLabel="리뷰 리스트"
-                      currentElement={pageIndex * 12 + reviewIndex + 1}
-                    />
-                  </li>
-                ))
-              : null,
+            page.data.content.map((review, reviewIndex) => (
+              <li key={`${filters.sortOrder}-${review.reviewId}`}>
+                <ReviewCard
+                  reviewId={review.reviewId}
+                  nickname={review.nickname}
+                  profileImage={review.profileImage}
+                  reviewImage={review.reviewImage}
+                  title={review.title}
+                  content={review.content}
+                  starRating={review.starRating}
+                  travelLocation={review.travelLocation}
+                  createdAt={review.createdAt}
+                  likesFlag={review.likesFlag ?? false}
+                />
+                <ListSkip.Link
+                  skipId="review-list-end"
+                  skipLabel="리뷰 리스트"
+                  currentElement={pageIndex * 12 + reviewIndex + 1}
+                />
+              </li>
+            )),
           )}
         </ul>
       )}

--- a/src/components/travel/list/filter/FilterDomestic.tsx
+++ b/src/components/travel/list/filter/FilterDomestic.tsx
@@ -31,7 +31,6 @@ const FilterDomestic = () => {
       </ListboxButton>
       <ListboxOptions
         anchor="bottom"
-        transition
         className="body-2-m z-20 flex w-[90px] flex-col items-center justify-center rounded border-line-normal bg-white text-label-alternative shadow-custom transition duration-100 ease-in [--anchor-gap:4px] [--anchor-padding:20px]"
       >
         <ListboxOption

--- a/src/components/travel/list/filter/FilterSort.tsx
+++ b/src/components/travel/list/filter/FilterSort.tsx
@@ -24,7 +24,6 @@ const FilterSort = () => {
       </ListboxButton>
       <ListboxOptions
         anchor="bottom"
-        transition
         className="body-2-m z-20 flex w-[90px] flex-col items-center justify-center rounded border-line-normal bg-white text-label-alternative shadow-custom transition duration-100 ease-in [--anchor-gap:4px] [--anchor-padding:20px]"
       >
         <ListboxOption

--- a/src/queries/review/useCreateReviewSelectTravel.ts
+++ b/src/queries/review/useCreateReviewSelectTravel.ts
@@ -9,7 +9,7 @@ const useCreateReviewSelectTravel = () => {
     queryFn: ({ pageParam = 0 }) => getWritableTravelReview(size, pageParam),
     initialPageParam: 0,
     getNextPageParam: (lastPage, pages) => {
-      return lastPage.hasNext ? pages.length : undefined;
+      return lastPage.data.hasNext ? pages.length : undefined;
     },
     staleTime: Infinity,
   });

--- a/src/queries/travel/useGetTravelsList.ts
+++ b/src/queries/travel/useGetTravelsList.ts
@@ -9,7 +9,7 @@ const useGetTravelsList = (filters: Filters) => {
     queryFn: ({ pageParam = 0 }) => getTravels({ ...filters, pageParam }),
     initialPageParam: 0,
     getNextPageParam: (lastPage, pages) => {
-      return lastPage.hasNext ? pages.length : undefined;
+      return lastPage.data.hasNext ? pages.length : undefined;
     },
   });
 };


### PR DESCRIPTION
## 작업 개요

> 여행 리스트 탈출 버튼 적용, 이미지 onload 수정, 테스트 코드 에러사항 수정 반영

## 작업 상세
- 여행 리스트 `ListSkip` 반영했습니다. `ListSkip.Link` li 태그를 div로 변경했습니다.
- 탈출하기 버튼을 눌러도 다음 페이지를 로드 하는 이슈가 있었습니다.
   skipMode 상태를 만들어 일정시간(8초) 동안은 `fetchNextPage`가 동작하지 못하도록 막았습니다.
- next.js 14버전부터 Image 컴포넌트의 onLoadingComplete가 onLoade로 변경되었다고 합니다.
  `TravelCardBig`의 이미지 컴포넌트 onLoade로 수정했습니다. 나머지 컴포넌트들은 차례로 수정하면 될 것 같습니다.
- 그 외 테스트에서 에러나는 사항 수정했습니다


## 작업 결과 (스크린샷 및 gif)

![skipmode](https://github.com/user-attachments/assets/1d2a52e5-06eb-47f7-bd29-540ba580b67f)

